### PR TITLE
Remove secrets from rsync client and server

### DIFF
--- a/applications/repo-hk/configmap.yaml
+++ b/applications/repo-hk/configmap.yaml
@@ -83,8 +83,6 @@ data:
           path = /repo/openeuler
           comment = openeuler repo folder
           read only = true
-          auth users = repo
-          secrets file = /etc/rsyncd.server.secrets
           ignore nonreadable = yes
           refuse options = checksum
           dont compress = *

--- a/applications/repo-hk/deployment.yaml
+++ b/applications/repo-hk/deployment.yaml
@@ -60,14 +60,8 @@ spec:
               sed -i "s/<password>/${PASSWORD}/g" ~/.fscrawler/openeuler/_settings.yaml
               exec fscrawler openeuler
         - name: rsync-server
-          image: swr.ap-southeast-1.myhuaweicloud.com/opensourceway/repo-client:cf6df893333da15daf1b0ade7ef03db3a83e1b6e
+          image: swr.ap-southeast-1.myhuaweicloud.com/opensourceway/repo-client:d8e5d2d93ffbeae4ec0ea9372c47cd6d1853fb14
           volumeMounts:
-            - mountPath: /etc/rsyncd.secrets.ro
-              name: rsync-secrets-volume
-              subPath: rsyncd_secrets
-            - mountPath: /etc/rsyncd.server.secrets.ro
-              name: rsync-secrets-volume
-              subPath: rsync_server_secrets
             - mountPath: /repo/openeuler
               name: data-volume
             - mountPath: /root/.ssh/authorized_keys.ro
@@ -87,10 +81,6 @@ spec:
             - /bin/sh
             - -c
             - |
-              cp /etc/rsyncd.secrets.ro /etc/rsyncd.secrets
-              cp /etc/rsyncd.server.secrets.ro /etc/rsyncd.server.secrets
-              chmod 0400 /etc/rsyncd.secrets
-              chmod 0400 /etc/rsyncd.server.secrets
               /usr/bin/rsync --daemon --config /etc/rsyncd.conf
               exec tini -- entrypoint.sh
           resources:

--- a/applications/repo-hk/secrets.yaml
+++ b/applications/repo-hk/secrets.yaml
@@ -5,15 +5,9 @@ metadata:
 spec:
   name: rsync-secrets
   keysMap:
-    rsyncd_secrets:
-      path: secrets/data/openeuler/rsync
-      key: rsyncd_secrets
     password:
       path: secrets/data/infra-common/fluent
       key: es_password
     username:
       path: secrets/data/infra-common/fluent
       key: es_username
-    rsync_server_secrets:
-      path: secrets/data/openeuler/rsync
-      key: rsync_server_secrets


### PR DESCRIPTION
Now sync from beijing repo server and hongkong rsync server itself will not require password.

take hongkong repo server for example:
```
rsync -av --partial --progress  rsync://repo.openeuler.org:30873/openeuler/ 
```