### PR TITLE
Remove kind/wait_for_update label

### DIFF
--- a/applications/bot/debug/configmap.yaml
+++ b/applications/bot/debug/configmap.yaml
@@ -16,6 +16,7 @@ data:
       - lgtm
       - approved
       - ci_successful
+      - kind/wait_for_update
     checkPrReviewer: true
     # Tips for setting reviewers
     setReviewerTip: "Please assign one reviewer at least, visit https://gitee.com/mindspore/community/tree/master/sigs to check all sigs and maintainers in community."


### PR DESCRIPTION
openEuler Customization Requirement：remove kind/wait_for_update label while another commit push to the pr after kind/wait_for_update label added by ”/kind wait_for_updae“ comment.