### PR TITLE
Remove kunpeng jenkins service eip

### DIFF
--- a/applications/kunpeng/service.yaml
+++ b/applications/kunpeng/service.yaml
@@ -2,12 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jenkins
-  annotations:
-    kubernetes.io/elb.class: union
-    kubernetes.io/elb.id: 24253a5d-f47a-462e-bee9-586b880900a9
-    kubernetes.io/elb.lb-algorithm: ROUND_ROBIN
 spec:
-  externalTrafficPolicy: Local
   ports:
     - name: http
       port: 80
@@ -15,7 +10,6 @@ spec:
     - name: slavelistener
       port: 50000
       targetPort: 50000
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Now ip access will be disabled, instead domain name is required:
https://kunpengaccci.osinfra.cn/