### PR TITLE
Add the yaml file of the cve-manager-agent service

### DIFF
--- a/applications/cve-manager-agent/deployment.yaml
+++ b/applications/cve-manager-agent/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             httpGet:
               path: /cve/healthz/readiness
               port: 80
-            livenessProbe:               #存活探针
-              initialDelaySeconds: 60    #延迟加载时间
-              periodSeconds: 5           #重试时间间隔
-              timeoutSeconds: 5          #超时时间设置
-              failureThreshold: 3        #探测失败的重试次数
-              httpGet:
-                path: /cve/healthz/liveness
-                port: 80
+          livenessProbe:               #存活探针
+            initialDelaySeconds: 60    #延迟加载时间
+            periodSeconds: 5           #重试时间间隔
+            timeoutSeconds: 5          #超时时间设置
+            failureThreshold: 3        #探测失败的重试次数
+            httpGet:
+              path: /cve/healthz/liveness
+              port: 80

--- a/applications/cve-manager-agent/deployment.yaml
+++ b/applications/cve-manager-agent/deployment.yaml
@@ -20,12 +20,12 @@ spec:
             - name: TRACK_GITEE_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: cve-secrets
+                  name: cve-secrets-agent
                   key: gitee_token
             - name: TRACK_GITEE_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: cve-secrets
+                  name: cve-secrets-agent
                   key: gitee_account
             - name: TZ
               value: Asia/Shanghai

--- a/applications/cve-manager-agent/deployment.yaml
+++ b/applications/cve-manager-agent/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: cve-manager-agent
+  name: cve-manager-agent
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: cve-manager-agent
+  template:
+    metadata:
+      labels:
+        app: cve-manager-agent
+    spec:
+      containers:
+        - env:
+            - name: TRACK_GITEE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cve-secrets
+                  key: gitee_token
+            - name: TRACK_GITEE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: cve-secrets
+                  key: gitee_account
+            - name: TZ
+              value: Asia/Shanghai
+          image: swr.cn-north-4.myhuaweicloud.com/opensourceway/openeuler/cve-manager-agent:v1
+          imagePullPolicy: IfNotPresent
+          name: cve-manager-agent
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP

--- a/applications/cve-manager-agent/deployment.yaml
+++ b/applications/cve-manager-agent/deployment.yaml
@@ -36,3 +36,19 @@ spec:
             - containerPort: 80
               name: http
               protocol: TCP
+          readinessProbe:              #就绪探针
+            initialDelaySeconds: 20    #延迟加载时间
+            periodSeconds: 5           #重试时间间隔
+            timeoutSeconds: 10         #超时时间设置
+            failureThreshold: 5        #探测失败的重试次数
+            httpGet:
+              path: /cve/healthz/readiness
+              port: 80
+            livenessProbe:               #存活探针
+              initialDelaySeconds: 60    #延迟加载时间
+              periodSeconds: 5           #重试时间间隔
+              timeoutSeconds: 5          #超时时间设置
+              failureThreshold: 3        #探测失败的重试次数
+              httpGet:
+                path: /cve/healthz/liveness
+                port: 80

--- a/applications/cve-manager-agent/kustomization.yaml
+++ b/applications/cve-manager-agent/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml
+- secrets.yaml
+commonLabels:
+  app: cve-manager-agent
+  owner: zhangjianjun
+commonAnnotations:
+  email: 841670711@qq.com
+  owner: zhangjianjun
+namespace: cve-manager-agent
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/applications/cve-manager-agent/namespace.yaml
+++ b/applications/cve-manager-agent/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: cve-manager-agent
+  name: cve-manager-agent

--- a/applications/cve-manager-agent/secrets.yaml
+++ b/applications/cve-manager-agent/secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: cve-secrets-agent
+spec:
+  name: cve-secrets-agent
+  keysMap:
+    gitee_token:
+      path: secrets/data/openeuler/cve-manager-agent
+      key: gitee_token
+    gitee_account:
+      path: secrets/data/openeuler/cve-manager-agent
+      key: gitee_account

--- a/applications/cve-manager-agent/service.yaml
+++ b/applications/cve-manager-agent/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cve-manager-agent
+  namespace: cve-manager-agent
+spec:
+  ports:
+    - name: cve-manager-agent
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: cve-manager-agent
+  type: ClusterIP


### PR DESCRIPTION
Add the yaml file of the cve-manager-agent service
1. Provide five documents:
cve-manager-agent/deployment.yaml;
cve-manager-agent/kustomization.yaml;
cve-manager-agent/namespace.yaml;
cve-manager-agent/secrets.yaml;
cve-manager-agent/service.yaml;

cve-manager-agent is mainly an interface provided by an integrated tool, and currently integrates the function of automatically discovering packages