### PR TITLE
supplements env for zoom webinar

### DIFF
--- a/applications/meeting-server/deployment.yaml
+++ b/applications/meeting-server/deployment.yaml
@@ -37,6 +37,16 @@ spec:
                 secretKeyRef:
                   key: secret_access_key
                   name: meeting-server-secrets
+            - name: WEBINAR_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: webinar_host
+                  name: meeting-server-secrets
+            - name: WEBINAR_TEMPLATE_ID
+              valueFrom:
+                secretKeyRef:
+                  key: webinar_template_id
+                  name: meeting-server-secrets
             - name: OBS_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/applications/meeting-server/secrets.yaml
+++ b/applications/meeting-server/secrets.yaml
@@ -74,3 +74,9 @@ spec:
     query_token:
       path: secrets/data/openeuler/meeting-server
       key: query_token
+    webinar_host:
+      path: secrets/data/openeuler/meeting-server
+      key: webinar_host
+    webinar_template_id:
+      path: secrets/data/openeuler/meeting-server
+      key: webinar_template_id


### PR DESCRIPTION
After a online activity published, the mini-program should have scheduled a webinar for the activity, but it failed because of the lack of env