### PR TITLE
upgrade version of jquery to fix security vulnerability

### DIFF
--- a/applications/mail/config.yaml
+++ b/applications/mail/config.yaml
@@ -1647,7 +1647,7 @@ data:
     		</div>
     	</footer>
     
-    	<script src="{% static 'postorius/libs/jquery/jquery-1.11.3.min.js' %}"></script>
+    	<script src="{% static 'postorius/libs/jquery/jquery-3.6.0.min.js' %}"></script>
     	<script src="{% static 'postorius/libs/bootstrap/js/bootstrap.min.js' %}"></script>
     	<script src="{% static 'django-mailman3/js/main.js' %}"></script>
     	<script src="{% static 'postorius/js/script.js' %}"></script>

--- a/applications/mail/webservice.yaml
+++ b/applications/mail/webservice.yaml
@@ -34,6 +34,11 @@ spec:
           #disable signup page for mailman web hyperkitty
           cp /opt/mailman-web-config/base2.html /usr/lib/python3.6/site-packages/hyperkitty/templates/hyperkitty/base.html
           cp /opt/mailman-web-config/email.py /usr/lib/python3.6/site-packages/hyperkitty/models/email.py
+          # upgrade version of jquery to fix security vulnerability
+          rm -f /usr/lib/python3.6/site-packages/postorius/static/postorius/libs/jquery/jquery-1.11.3.min.js
+          wget https://code.jquery.com/jquery-3.6.0.js -O /usr/lib/python3.6/site-packages/postorius/static/postorius/libs/jquery/jquery-3.6.0.js
+          wget https://code.jquery.com/jquery-3.6.0.min.js -O /usr/lib/python3.6/site-packages/postorius/static/postorius/libs/jquery/jquery-3.6.0.min.js
+          wget https://code.jquery.com/jquery-3.6.0.min.map -O /usr/lib/python3.6/site-packages/postorius/static/postorius/libs/jquery/jquery-3.6.0.min.map
           exec docker-entrypoint.sh uwsgi --ini /opt/mailman-web/uwsgi.ini;
         env:
         - name: PRIVACY_LINK


### PR DESCRIPTION
为修复因jquery版本过低暴露的安全漏洞，修改postorius的base.html中的jquery版本至3.6.0，并在static中删除jquery的旧版本文件，新增3.6.0版本的文件